### PR TITLE
Remove auto update

### DIFF
--- a/ModAssistant/Classes/Updater.cs
+++ b/ModAssistant/Classes/Updater.cs
@@ -40,7 +40,7 @@ namespace ModAssistant
             CurrentVersion = new Version(App.Version);
 
 
-            return (LatestVersion > CurrentVersion);
+            return (false);
         }
 
         public static void Run()

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+### This fork of ModAssistant removes anti-piracy measures and client auto-updates
+Buy Beat Saber! Seriously, it's very good! These builds are intended for modding an old version of Beat Saber (v1.5.0).
+
+### BSIPA
+After running ModAssistant to install your mods, your BSIPA files will likely be replaced with something that have their own anti-piracy measures. There is a build that fixes that [here](https://github.com/Ynng/BeatSaber-IPA-Reloaded/releases/tag/3.13.2-p). Keep a copy backed up in case it gets overwritten again.
+
+# Below is the original readme
+
 # ModAssistant
 Simple Beat Saber Mod Installer similar to the [Beat Saber Mod Manager](https://github.com/beat-saber-modding-group/BeatSaberModInstaller)
 


### PR DESCRIPTION
Auto-update fires when launching the app, completely overwriting the anti-anti-piracy version. This change prevents auto-updates from occurring.